### PR TITLE
[TASK-54] chore: configuration specifications: pre-commit, flake8, isort, black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E712, E203
+max-line-length = 120

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+profile = black
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py311-plus]
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Configurations for: 
- `flake8`
- `isort`
- `black` (formatter)
- `pre-commit`

## Documentation:
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
[Using Black with other tools](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html)
[pre-commit](https://pre-commit.com/)