### PR TITLE
feat: admin user

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import Enum as SqlAlchemyEnum
 from sqlalchemy import ForeignKey, Table
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from utils import Status
+from utils import Status, UserRole
 
 
 class Base(DeclarativeBase):
@@ -20,9 +20,7 @@ class User(Base):
     last_name: Mapped[str]
     email: Mapped[str] = mapped_column(unique=True)
     active: Mapped[bool] = mapped_column(default=False)
-
-
-# TODO: create admin user
+    role: Mapped[str] = mapped_column(SqlAlchemyEnum(UserRole), default=UserRole.USER)
 
 
 class Metric(Base):

--- a/utils.py
+++ b/utils.py
@@ -4,3 +4,8 @@ import enum
 class Status(enum.Enum):
     ACTIVE = "active"
     COMPLETED = "completed"
+
+
+class UserRole(enum.Enum):
+    ADMIN = "admin"
+    USER = "user"


### PR DESCRIPTION
- Adding `UserRole` enum with two options: `ADMIN` and `USER`
- Adding `role` attribute in `User` model, which has the value of "user" by default